### PR TITLE
service: meson.build: Fix executable install_dir

### DIFF
--- a/service/meson.build
+++ b/service/meson.build
@@ -17,4 +17,5 @@ reportd_dependencies = [
 executable('reportd', reportd_sources,
   dependencies: reportd_dependencies,
   install: true,
+  install_dir: get_option('libexecdir'),
 )


### PR DESCRIPTION
It used to be libexecdir, not bindir.

Signed-off-by: Ernestas Kulik <ekulik@redhat.com>