### PR TITLE
Add libreport_ to libreport function calls and globals

### DIFF
--- a/src/reportd-main.c
+++ b/src/reportd-main.c
@@ -53,7 +53,7 @@ main (int    argc,
     sigint_source = g_unix_signal_add (SIGINT, on_signal_quit, daemon);
     sigterm_source = g_unix_signal_add (SIGTERM, on_signal_quit, daemon);
 
-    load_user_settings ("reportd");
+    libreport_load_user_settings ("reportd");
 
     status = reportd_daemon_run (daemon, &error);
     if (status != EXIT_SUCCESS)
@@ -61,7 +61,7 @@ main (int    argc,
         g_warning ("Daemon stopped with an error: %s", error->message);
     }
 
-    save_user_settings ();
+    libreport_save_user_settings ();
 
     g_clear_handle_id (&sigint_source, g_source_remove);
     g_clear_handle_id (&sigterm_source, g_source_remove);

--- a/src/reportd-service.c
+++ b/src/reportd-service.c
@@ -378,7 +378,7 @@ static void
 reportd_service_init (ReportdService *self)
 {
     self->service_iface = reportd_dbus_service_skeleton_new ();
-    self->workflows = load_workflow_config_data (NULL);
+    self->workflows = libreport_load_workflow_config_data (NULL);
     self->tasks = g_hash_table_new_full (g_str_hash, g_str_equal,
                                          g_free, (GDestroyNotify) g_ptr_array_unref);
 

--- a/src/reportd-task.c
+++ b/src/reportd-task.c
@@ -304,13 +304,13 @@ reportd_task_ask_yes_no_yesforever_callback (const char *key,
     bool response;
     bool remember;
 
-    value = get_user_setting (key);
+    value = libreport_get_user_setting (key);
     /* The following is replicating the madness inside libreport, where
      * “no” means “yes, forever”, and “yes” means nothing, really.
      *
      * Yes (no?), each implementation has a similar comment.
      */
-    if (value != NULL && !string_to_bool(value))
+    if (value != NULL && !libreport_string_to_bool(value))
     {
         return TRUE;
     }
@@ -324,7 +324,7 @@ reportd_task_ask_yes_no_yesforever_callback (const char *key,
     remember = reportd_dbus_task_prompt_get_remember (prompt_interface);
     if (remember && !response)
     {
-        set_user_setting (key, "no");
+        libreport_set_user_setting (key, "no");
     }
 
     return response;
@@ -341,10 +341,10 @@ reportd_task_ask_yes_no_save_result_callback (const char *key,
     bool response;
     bool remember;
 
-    value = get_user_setting (key);
+    value = libreport_get_user_setting (key);
     if (value != NULL)
     {
-        return string_to_bool (value);
+        return libreport_string_to_bool (value);
     }
     self = REPORTD_TASK (interaction_param);
     prompt_interface = reportd_task_emit_prompt (self, msg, ASK_YES_NO_SAVE);
@@ -358,7 +358,7 @@ reportd_task_ask_yes_no_save_result_callback (const char *key,
     {
         value = response? "yes" : "no";
 
-        set_user_setting (key, value);
+        libreport_set_user_setting (key, value);
     }
 
     return response;


### PR DESCRIPTION
This PR fixes what abrt/libreport#609 breaks.

See also https://github.com/abrt/abrt/pull/1467, https://github.com/abrt/abrt-java-connector/pull/7

Signed-off-by: Michal Fabik <mfabik@redhat.com>